### PR TITLE
feat(ci): add automatic version bump #31

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,20 @@
+[bumpversion]
+current_version = 0.1.0-dev
+tag = True
+commit = True
+commit_args = --no-verify
+commit_message = "chore: bump version to {new_version} 🎉"
+
+parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(-(?P<release>[a-z]+))?
+serialize = {major}.{minor}.{patch}-dev
+
+[bumpversion:file:./src/__init__.py]
+[bumpversion:file:./src/gpac_api/app/__init__.py]
+[bumpversion:file:./src/gpac_api/app/models/__init__.py]
+[bumpversion:file:./src/gpac_api/app/schemas/__init__.py]
+[bumpversion:file:./src/gpac_api/app/crud/__init__.py]
+[bumpversion:file:./src/gpac_api/app/db/__init__.py]
+[bumpversion:file:./src/gpac_api/app/api/endpoints/__init__.py]
+[bumpversion:file:./src/gpac_api/app/api/__init__.py]
+[bumpversion:file:./src/gpac_api/__init__.py]
+[bumpversion:file:./pyproject.toml]

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,12 +1,10 @@
-name: Update changelog
+name: Update changelog and bump version
 'on':
   push:
     branches:
       - master
-    tags:
-      - v*
 jobs:
-  update_changelog:
+  bump_version:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -25,23 +23,20 @@ jobs:
           pipx install poetry
           poetry install
 
-      - name: Generate changelog
+      - name: Commit and Push Changelog and Bump Version
         run: |
-          poetry run git cliff -o CHANGELOG.md
-
-      - name: Commit and Push Changelog
-        run: >
           set -e  # Exit immediately if a command exits with a non-zero status
 
-
           git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
-          git config --global user.email
-          "github-actions[bot]@users.noreply.github.com"
+          poetry run git cliff -o CHANGELOG.md
 
-
+          git add -u
           git add CHANGELOG.md
 
-          git commit -m "chore: update changelog" || echo "No changes to commit"
+          git commit -m "chore: update changelog"
 
-          git push https://x-access-token:${{ secrets.GH_PAT }}@github.com/mihamieat/gpac-api.git master
+          poetry run bump2version minor
+
+          git push https://x-access-token:${{ secrets.GH_PAT }}@github.com/mihamieat/gpac-api.git master --follow-tags

--- a/poetry.lock
+++ b/poetry.lock
@@ -94,6 +94,17 @@ jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
 uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
+name = "bump2version"
+version = "1.0.1"
+description = "Version-bump your software with a single command!"
+optional = false
+python-versions = ">=3.5"
+files = [
+    {file = "bump2version-1.0.1-py2.py3-none-any.whl", hash = "sha256:37f927ea17cde7ae2d7baf832f8e80ce3777624554a653006c9144f8017fe410"},
+    {file = "bump2version-1.0.1.tar.gz", hash = "sha256:762cb2bfad61f4ec8e2bdf452c7c267416f8c70dd9ecb1653fd0bbb01fa936e6"},
+]
+
+[[package]]
 name = "certifi"
 version = "2024.7.4"
 description = "Python package for providing Mozilla's CA Bundle."
@@ -1583,4 +1594,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "e05b25ed099fb68d68689124104b706749c4d06a8995e412e4ebfb478870f27d"
+content-hash = "2ddc4d88837aa8b3fc06bdfa83138ea2677537a8f02f380b02cf0bdb8acfe585"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gpac-api"
-version = "0.1.0"
+version = "0.1.0-dev"
 description = ""
 authors = ["Mihamina Rakotovazaha <r.miham@yahoo.com>", "Stephane Vusasinovic stephane.vujasinovic@gmail.com"]
 readme = "README.md"
@@ -21,6 +21,7 @@ python-dotenv = "^1.0.1"
 pylint = "^3.2.6"
 python-dateutil = "^2.9.0.post0"
 git-cliff = "^2.8.0"
+bump2version = "^1.0.1"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+"""Project source package."""
+__version__ = "0.1.0-dev"

--- a/src/gpac_api/__init__.py
+++ b/src/gpac_api/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+"""Project API package."""
+__version__ = "0.1.0-dev"

--- a/src/gpac_api/app/__init__.py
+++ b/src/gpac_api/app/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+"""Project app package."""
+__version__ = "0.1.0-dev"

--- a/src/gpac_api/app/api/__init__.py
+++ b/src/gpac_api/app/api/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+"""API endpoints package."""
+__version__ = "0.1.0-dev"

--- a/src/gpac_api/app/api/endpoints/__init__.py
+++ b/src/gpac_api/app/api/endpoints/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+"""App endpoints package."""
+__version__ = "0.1.0-dev"

--- a/src/gpac_api/app/crud/__init__.py
+++ b/src/gpac_api/app/crud/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+"""App crud operations package."""
+__version__ = "0.1.0-dev"

--- a/src/gpac_api/app/db/__init__.py
+++ b/src/gpac_api/app/db/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+"""App database package."""
+__version__ = "0.1.0-dev"

--- a/src/gpac_api/app/models/__init__.py
+++ b/src/gpac_api/app/models/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+"""App models package."""
+__version__ = "0.1.0-dev"

--- a/src/gpac_api/app/schemas/__init__.py
+++ b/src/gpac_api/app/schemas/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+"""App schemas package."""
+__version__ = "0.1.0-dev"

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+"""Test package."""
+__version__ = "0.1.0-dev"


### PR DESCRIPTION
closes #31

## Summary by Sourcery

CI:
- Set up automatic version bumping using `bump2version`. The changelog is generated and committed along with the version bump in a single workflow. The version is bumped using the `minor` strategy. The workflow is triggered on pushes to the `master` branch. The workflow also tags the commit with the new version. The version is also updated in the `__init__.py` files of the project and in the `pyproject.toml` file. A `.bumpversion.cfg` file is added to configure `bump2version`