### PR TITLE
chore: re-integrate code coverage results

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,14 +68,16 @@ jobs:
         with:
           mongodb-version: ${{ matrix.mongodb-version }}
       - name: Run Tests
-        run: poetry run pytest --cov=src tests/ --junitxml=junit.xml -o junit_family=legacy
+        run: poetry run pytest --cov=src --cov-report=xml
       - name: Upload coverage report
         uses: actions/upload-artifact@v4
         with:
           name: coverage-report-${{ matrix.mongodb-version }}
-          path: junit.xml
+          path: coverage.xml
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/codecov-action@v5
         with:
+          fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage.xml


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Re-integrate code coverage results by uploading `coverage.xml` to Codecov, and fail the CI if Codecov upload fails.